### PR TITLE
Fix invalid authorization check in contract deployment

### DIFF
--- a/gxc.system/src/native.cpp
+++ b/gxc.system/src/native.cpp
@@ -37,7 +37,7 @@ void contract::newaccount(name creator, name name, ignore<authority> owner, igno
 }
 
 void contract::setabi(name account, const std::vector<char>& abi) {
-   eosio_assert(!starts_with(account, "gxc."), "not allowed to normal account");
+   eosio_assert(has_dot(account), "not allowed to normal account");
 
    eosio::multi_index<"abihash"_n, abi_hash> table(_self, _self.value);
 
@@ -55,7 +55,7 @@ void contract::setabi(name account, const std::vector<char>& abi) {
 }
 
 void contract::setcode(name account, uint8_t vmtype, uint8_t vmversion, const std::vector<char>& code) {
-   eosio_assert(!starts_with(account, "gxc."), "not allowed to normal account");
+   eosio_assert(has_dot(account), "not allowed to normal account");
 }
 
 } }


### PR DESCRIPTION
All system accounts have prefix (`gxc.` or `token.`) currently. This condition can be changed in the future.