### PR TITLE
Improve token contract

### DIFF
--- a/contracts/gxc.token/include/gxc.token/gxc.token.hpp
+++ b/contracts/gxc.token/include/gxc.token/gxc.token.hpp
@@ -26,10 +26,10 @@ namespace gxc {
       void create(extended_asset max_supply, std::vector<key_value> opts);
 
       [[eosio::action]]
-      void transfer(name from, name to, extended_asset quantity, std::string memo);
+      void transfer(name from, name to, extended_asset value, std::string memo);
 
       [[eosio::action]]
-      void burn(extended_asset quantity, std::string memo);
+      void burn(extended_asset value, std::string memo);
 
       [[eosio::action]]
       void setopts(name issuer, symbol symbol, std::vector<key_value> opts);
@@ -44,10 +44,10 @@ namespace gxc {
       void close(name owner, name issuer, symbol symbol);
 
       [[eosio::action]]
-      void deposit(name owner, extended_asset quantity);
+      void deposit(name owner, extended_asset value);
 
       [[eosio::action]]
-      void withdraw(name owner, extended_asset quantity);
+      void withdraw(name owner, extended_asset value);
 
       [[eosio::action]]
       void clearreqs(name owner);

--- a/contracts/gxc.token/include/gxc.token/gxc.token.hpp
+++ b/contracts/gxc.token/include/gxc.token/gxc.token.hpp
@@ -227,9 +227,9 @@ namespace gxc {
       private:
          const token* _st;
 
-         void sub_balance(extended_asset value);
+         void sub_balance(extended_asset value, bool keep_balance = false);
          void add_balance(extended_asset value);
-         void sub_deposit(extended_asset value);
+         void sub_deposit(extended_asset value, bool keep_balance = false);
          void add_deposit(extended_asset value);
 
          friend class token;

--- a/contracts/gxc.token/include/gxc.token/gxc.token.hpp
+++ b/contracts/gxc.token/include/gxc.token/gxc.token.hpp
@@ -69,7 +69,10 @@ namespace gxc {
             _deposit = quantity.amount;
          }
          bool get_opt(opt option)const { return (_id >> (56 + option)) & 0x1; }
-         void set_opt(opt option, bool val) { _id |= (val & 0x1) << (56 + option); }
+         void set_opt(opt option, bool val) {
+            if (val) _id |= 0x1 << (56 + option);
+            else     _id &= ~(0x1 << (56 + option));
+         }
          void set_primary_key(uint64_t id) {
             check(id <= 0x00FFFFFFFFFFFFFFULL, "uppermost byte of `_id` is reserved for options");
             _id = (_id & 0xFF00000000000000ULL) | id;
@@ -103,7 +106,10 @@ namespace gxc {
             _max_supply = quantity.amount;
          }
          bool get_opt(opt option)const { return (_opts >> (0 + option)) & 0x1; }
-         void set_opt(opt option, bool val) { _opts |= (val & 0x1) << option; }
+         void set_opt(opt option, bool val) {
+            if (val) _opts |= 0x1 << option;
+            else     _opts &= ~(0x1 << option);
+         }
          asset get_withdraw_min_amount()const { return asset(_withdraw_min_amount, supply.symbol); }
          void set_withdraw_min_amount(const asset& quantity) {
             check(quantity.symbol == supply.symbol, "symbol mismatch");

--- a/contracts/gxc.token/src/account.cpp
+++ b/contracts/gxc.token/src/account.cpp
@@ -14,10 +14,14 @@ namespace gxc {
          for (auto o : opts) {
             if (o.key == "frozen") {
                check((*_st)->get_opt(token::opt::can_freeze), "not configured to freeze account");
-               a.set_opt(opt::frozen, static_cast<bool>(o.value[0]));
+               auto value = unpack<bool>(o.value);
+               check(a.get_opt(opt::frozen) != value, "option already has give value");
+               a.set_opt(opt::frozen, value);
             } else if (o.key == "whitelist") {
                check((*_st)->get_opt(token::opt::can_whitelist), "not configured to whitelist account");
-               a.set_opt(opt::whitelist, static_cast<bool>(o.value[0]));
+               auto value = unpack<bool>(o.value);
+               check(a.get_opt(opt::whitelist) != value, "option already has give value");
+               a.set_opt(opt::whitelist, value);
             } else {
                check(false, "unknown option `" + o.key + "`");
             }

--- a/contracts/gxc.token/src/account.cpp
+++ b/contracts/gxc.token/src/account.cpp
@@ -25,11 +25,11 @@ namespace gxc {
       });
    }
 
-   void token_contract::account::sub_balance(extended_asset value) {
+   void token_contract::account::sub_balance(extended_asset value, bool keep_balance) {
       check_account_is_valid();
       check(_this->balance.amount >= value.quantity.amount, "overdrawn balance");
 
-      if (!_this->get_opt(opt::whitelist) &&
+      if (!_this->get_opt(opt::whitelist) && !keep_balance &&
           _this->balance.amount == value.quantity.amount &&
           _this->get_deposit().amount == 0)
       {
@@ -58,11 +58,11 @@ namespace gxc {
       }
    }
 
-   void token_contract::account::sub_deposit(extended_asset value) {
+   void token_contract::account::sub_deposit(extended_asset value, bool keep_balance) {
       check_account_is_valid();
       check(_this->get_deposit().amount >= value.quantity.amount, "overdrawn deposit");
 
-      if (!_this->get_opt(opt::whitelist) &&
+      if (!_this->get_opt(opt::whitelist) && !keep_balance &&
           _this->get_deposit().amount == value.quantity.amount &&
           _this->balance.amount == 0)
       {

--- a/contracts/gxc.token/src/requests.cpp
+++ b/contracts/gxc.token/src/requests.cpp
@@ -17,7 +17,7 @@ namespace gxc {
          transaction out;
          out.actions.emplace_back(action{{owner(), active_permission}, code(), "clearreqs"_n, owner()});
 
-         auto withdraw_delay_sec = token(code(), _it->issuer, _it->quantity.symbol)->withdraw_delay_sec;
+         auto withdraw_delay_sec = token(code(), _it->value.contract, _it->value.quantity.symbol)->withdraw_delay_sec;
 
          if (_it->scheduled_time == base_time) {
             out.delay_sec = withdraw_delay_sec;
@@ -42,11 +42,11 @@ namespace gxc {
       check(_it != _idx.end(), "withdrawal requests not found");
 
       for ( ; _it != _idx.end(); _it = _idx.begin()) {
-         auto _token = token(code(), _it->issuer, _it->quantity.symbol);
+         auto _token = token(code(), _it->value.contract, _it->value.quantity.symbol);
          if (_it->scheduled_time > current_time_point()) break;
 
-         _token.get_account(code()).sub_balance(extended_asset(_it->quantity, _it->issuer));
-         _token.get_account(owner()).add_balance(extended_asset(_it->quantity, _it->issuer));
+         _token.get_account(code()).sub_balance(extended_asset(_it->value.quantity, _it->value.contract));
+         _token.get_account(owner()).add_balance(extended_asset(_it->value.quantity, _it->value.contract));
 
          _idx.erase(_it);
       }

--- a/contracts/gxc.token/src/token.cpp
+++ b/contracts/gxc.token/src/token.cpp
@@ -229,7 +229,7 @@ namespace gxc {
          });
       }
 
-      get_account(owner).sub_deposit(value);
+      get_account(owner).sub_deposit(value, true);
       get_account(code()).add_balance(value);
 
       _req.refresh_schedule(ctp + seconds(_this->withdraw_delay_sec));

--- a/contracts/libraries/include/gxclib/fasthash.h
+++ b/contracts/libraries/include/gxclib/fasthash.h
@@ -1,0 +1,97 @@
+/* The MIT License
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef _FASTHASH_H
+#define _FASTHASH_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Compression function for Merkle-Damgard construction.
+// This function is generated using the framework provided.
+#define mix(h) ({                   \
+      (h) ^= (h) >> 23;             \
+      (h) *= 0x2127599bf4325c37ULL; \
+      (h) ^= (h) >> 47; })
+
+/**
+ * fasthash64 - 64-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+uint64_t fasthash64(const void *buf, size_t len, uint64_t seed) {
+   const uint64_t    m = 0x880355f21e6d1965ULL;
+   const uint64_t *pos = (const uint64_t *)buf;
+   const uint64_t *end = pos + (len / 8);
+   const unsigned char *pos2;
+   uint64_t h = seed ^ (len * m);
+   uint64_t v;
+
+   while (pos != end) {
+      v  = *pos++;
+      h ^= mix(v);
+      h *= m;
+   }
+
+   pos2 = (const unsigned char*)pos;
+   v = 0;
+
+   switch (len & 7) {
+      case 7: v ^= (uint64_t)pos2[6] << 48;
+      case 6: v ^= (uint64_t)pos2[5] << 40;
+      case 5: v ^= (uint64_t)pos2[4] << 32;
+      case 4: v ^= (uint64_t)pos2[3] << 24;
+      case 3: v ^= (uint64_t)pos2[2] << 16;
+      case 2: v ^= (uint64_t)pos2[1] << 8;
+      case 1: v ^= (uint64_t)pos2[0];
+              h ^= mix(v);
+              h *= m;
+   }
+
+   return mix(h);
+}
+
+/**
+ * fasthash32 - 32-bit implementation of fasthash
+ * @buf:  data buffer
+ * @len:  data size
+ * @seed: the seed
+ */
+uint32_t fasthash32(const void *buf, size_t len, uint32_t seed) {
+   // the following trick converts the 64-bit hashcode to Fermat
+   // residue, which shall retain information from both the higher
+   // and lower parts of hashcode.
+   uint64_t h = fasthash64(buf, len, seed);
+   return h - (h >> 32);
+}
+
+#undef mix
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/contracts/libraries/include/gxclib/multi_index.hpp
+++ b/contracts/libraries/include/gxclib/multi_index.hpp
@@ -97,8 +97,8 @@ namespace eosio {
       }
 
       template<typename Lambda>
-      void modify(Lambda&& updater) {
-         _tbl.modify(_this, same_payer, std::forward<Lambda&&>(updater));
+      void modify(name payer, Lambda&& updater) {
+         _tbl.modify(_this, payer, std::forward<Lambda&&>(updater));
       }
 
       void erase() { _tbl.erase(_this); }


### PR DESCRIPTION
## Changes

* Change param name
`eosio::extended_asset` already contains a field named with `quantity`. Action parameters name with `quantity` is changed to `value`.

* Allow issuer to retire token from user deposit
Currently, game account should recall token from user account by `transfer` to its own account and send it to `gxc.null` to retire it. This patch allows issuer to send token to `gxc.null` directly from user deposit.

* Fix not working token option
Token options use bit masking to reduce RAM usage, but there was an error when clearing bit.

* Decrease RAM usage during withdrawal request
Withdrawal request had three indices, so it consumed too much RAM. By applying hashed 64-bit integer to primary key, its request will consume little RAM. (However, there can be hash collision from `eosio::extended_symbol_code` (128 bit) to `uint64_t`)

* Do not erase zero-balance during withdrawl request
Fixes Game-X-Coin/gxc#16