### PR TITLE
Introduce virtual account

### DIFF
--- a/contracts/gxc.token/include/gxc.token/gxc.token.hpp
+++ b/contracts/gxc.token/include/gxc.token/gxc.token.hpp
@@ -12,6 +12,7 @@
 #include <gxclib/key_value.hpp>
 #include <gxclib/multi_index.hpp>
 #include <gxclib/fasthash.h>
+#include <gxclib/action.hpp>
 
 using namespace eosio;
 

--- a/contracts/gxc.token/src/account.cpp
+++ b/contracts/gxc.token/src/account.cpp
@@ -8,7 +8,7 @@ namespace gxc {
 
    void token_contract::account::setopts(const std::vector<key_value>& opts) {
       check(opts.size(), "no changes on options");
-      require_auth(issuer());
+      require_vauth(issuer());
 
       _tbl.modify(_this, same_payer, [&](auto& a) {
          for (auto o : opts) {
@@ -47,7 +47,7 @@ namespace gxc {
 
    void token_contract::account::add_balance(extended_asset value) {
       if (!exists()) {
-         check(!(*_st)->get_opt(token::opt::enforce_whitelist) || has_auth(value.contract), "required to open balance manually");
+         check(!(*_st)->get_opt(token::opt::enforce_whitelist) || has_vauth(value.contract), "required to open balance manually");
          _tbl.emplace(code(), [&](auto& a) {
             a.set_primary_key(_tbl.available_primary_key());
             a.balance = value.quantity;
@@ -80,7 +80,7 @@ namespace gxc {
 
    void token_contract::account::add_deposit(extended_asset value) {
       if (!exists()) {
-         check(!(*_st)->get_opt(token::opt::enforce_whitelist) || has_auth(value.contract), "required to open deposit manually");
+         check(!(*_st)->get_opt(token::opt::enforce_whitelist) || has_vauth(value.contract), "required to open deposit manually");
          _tbl.emplace(code(), [&](auto& a) {
             a.set_primary_key(_tbl.available_primary_key());
             a.balance = asset(0, value.quantity.symbol);
@@ -96,7 +96,7 @@ namespace gxc {
    }
 
    void token_contract::account::open() {
-      require_auth(issuer());
+      require_vauth(issuer());
       if (!exists()) {
          _tbl.emplace(code(), [&](auto& a) {
             a.set_primary_key(_tbl.available_primary_key());

--- a/contracts/gxc.token/src/token.cpp
+++ b/contracts/gxc.token/src/token.cpp
@@ -51,7 +51,7 @@ namespace gxc {
 
    void token_contract::token::setopts(const std::vector<key_value>& opts) {
       check(opts.size(), "no changes on options");
-      require_auth(issuer());
+      require_vauth(issuer());
 
       _tbl.modify(_this, same_payer, [&](auto& t) {
          for (auto o : opts) {
@@ -73,7 +73,7 @@ namespace gxc {
    }
 
    void token_contract::token::issue(name to, extended_asset value) {
-      require_auth(value.contract);
+      require_vauth(value.contract);
       check_asset_is_valid(value);
       check(!_this->get_opt(opt::is_frozen), "token is frozen");
 
@@ -104,7 +104,7 @@ namespace gxc {
       bool is_recall = false;
 
       if (!has_auth(owner)) {
-         check(_this->get_opt(opt::can_recall) && has_auth(value.contract), "Missing required authority");
+         check(_this->get_opt(opt::can_recall) && has_vauth(value.contract), "Missing required authority");
          is_recall = true;
       }
 
@@ -121,7 +121,7 @@ namespace gxc {
    }
 
    void token_contract::token::burn(extended_asset value) {
-      require_auth(value.contract);
+      require_vauth(value.contract);
       check_asset_is_valid(value);
       check(!_this->get_opt(opt::is_frozen), "token is frozen");
 
@@ -146,7 +146,7 @@ namespace gxc {
       bool is_recall = false;
 
       if (!has_auth(from)) {
-         check(_this->get_opt(opt::can_recall) && has_auth(value.contract), "Missing required authority");
+         check(_this->get_opt(opt::can_recall) && has_vauth(value.contract), "Missing required authority");
          is_recall = true;
       }
 
@@ -173,7 +173,7 @@ namespace gxc {
          require_auth(owner);
          _owner.sub_balance(value);
       } else {
-         if (has_auth(issuer())) {
+         if (has_vauth(issuer())) {
             auto recallable = _req->value.quantity - value.quantity;
             check(recallable.amount >= 0, "cannot deposit more than withdrawal requested by issuer");
 

--- a/contracts/libraries/include/gxclib/action.hpp
+++ b/contracts/libraries/include/gxclib/action.hpp
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * @copyright defined in gxc/LICENSE
+ */
+#pragma once
+#include <eosiolib/action.h>
+
+namespace eosio {
+
+name rootname(const name& n) {
+   auto mask = (uint64_t) -1;
+   for (auto i = 0; i < 12; ++i) {
+      if (n.value & (0x1FULL << (4 + 5 * (11 - i))))
+         continue;
+      mask <<= 4 + 5 * (11 - i);
+      break;
+   }
+   return name(n.value & mask);
+}
+
+inline bool has_vauth(const name& n) {
+   return ::has_auth(rootname(n).value);
+}
+
+inline void require_vauth(const name& n) {
+   ::require_auth(rootname(n).value);
+}
+
+}


### PR DESCRIPTION
Game studio can provide his game with same contents, but multiple servers (or channels). In that case, there can be distinguishable, but same symbol tokens like `GOLD@game.serva` and `GOLD@game.servb`.

Instead of creating actual sub-accounts for each server (to distinguish token issuer), game account can have permission of virtual name `ACCOUNT_NAME + . + SERVER_NAME`. Virtual account names are also packed by `eosio::name`, so it should be encoded BASE32 and shorter or equal than 12 characters including dot and prefix (original game name). 

To support this, in `GXC`, it's forbidden from having `.` (dot) in normal account's name.