### PR TITLE
Notify that withdrawal requests are processed

### DIFF
--- a/contracts/gxc.token/include/gxc.token/gxc.token.hpp
+++ b/contracts/gxc.token/include/gxc.token/gxc.token.hpp
@@ -48,6 +48,9 @@ namespace gxc {
       void deposit(name owner, extended_asset value);
 
       [[eosio::action]]
+      void reqwithdraw(name owner, extended_asset value);
+
+      [[eosio::action]]
       void withdraw(name owner, extended_asset value);
 
       [[eosio::action]]

--- a/contracts/gxc.token/src/gxc.token.cpp
+++ b/contracts/gxc.token/src/gxc.token.cpp
@@ -69,8 +69,12 @@ namespace gxc {
       token(_self, value).deposit(owner, value);
    }
 
-   void token_contract::withdraw(name owner, extended_asset value) {
+   void token_contract::reqwithdraw(name owner, extended_asset value) {
       token(_self, value).withdraw(owner, value);
+   }
+
+   void token_contract::withdraw(name owner, extended_asset value) {
+      /* Do noting, but just for tracking withdraw */
    }
 
    void token_contract::clearreqs(name owner) {
@@ -78,4 +82,4 @@ namespace gxc {
    }
 }
 
-EOSIO_DISPATCH(gxc::token_contract, (create)(transfer)(burn)(setopts)(setacntopts)(open)(close)(deposit)(withdraw)(clearreqs))
+EOSIO_DISPATCH(gxc::token_contract, (create)(transfer)(burn)(setopts)(setacntopts)(open)(close)(deposit)(reqwithdraw)(withdraw)(clearreqs))

--- a/contracts/gxc.token/src/requests.cpp
+++ b/contracts/gxc.token/src/requests.cpp
@@ -48,6 +48,17 @@ namespace gxc {
          _token.get_account(code()).sub_balance(extended_asset(_it->value.quantity, _it->value.contract));
          _token.get_account(owner()).add_balance(extended_asset(_it->value.quantity, _it->value.contract));
 
+         action receipt;
+         receipt.account = code();
+         receipt.name    = name("withdraw");
+         receipt.data.resize(sizeof(name) + sizeof(extended_asset));
+
+         datastream<char*> ds(receipt.data.data(), receipt.data.size());
+         ds << owner();
+         ds << _it->value;
+
+         receipt.send_context_free();
+
          _idx.erase(_it);
       }
 


### PR DESCRIPTION
Resolves #25.

`withdraw` is renamed `reqwithdraw`. (request withdraw) and `clearreqs` will send inline actions named by `withdraw` corresponding to actually processed withdraws.