### PR TITLE
Fix build error due to missing function body

### DIFF
--- a/contracts/gxc.system/include/gxc.system/gxc.system.hpp
+++ b/contracts/gxc.system/include/gxc.system/gxc.system.hpp
@@ -70,7 +70,7 @@ public:
    [[eosio::action]] void setramrate (uint16_t bytes_per_block);
    [[eosio::action]] void setparams (const gxc::blockchain_parameters& params);
    [[eosio::action]] void setpriv (name account, uint8_t is_priv);
-   [[eosio::action]] void updtrevision (uint8_t revision);
+   [[eosio::action]] void updtrevision (uint8_t revision) {}
    [[eosio::action]] void genaccount (name creator, name name, authority owner, authority active, std::string nickname);
 
    // native action handelrs


### PR DESCRIPTION
Since CDT is upgraded to 1.6.x, the function without body causes build error during linking.