### PR TITLE
Fix incorrect function name in README

### DIFF
--- a/contracts/gxc.user/README.md
+++ b/contracts/gxc.user/README.md
@@ -7,7 +7,7 @@ Handles actions related to user accounts such as login or nickname register.
 ### connect
 
 ``` c++
-void login(name account_name, name game_name, string login_token);
+void connect(name account_name, name game_name, string login_token);
 ```
 
 Connect user account to game


### PR DESCRIPTION
`login` => `connect`