### PR TITLE
Mainnet configuration

### DIFF
--- a/contracts/gxc.system/include/gxc.system/gxc.system.hpp
+++ b/contracts/gxc.system/include/gxc.system/gxc.system.hpp
@@ -29,9 +29,16 @@ struct [[eosio::table("global"), eosio::contract("gxc.system")]] gxc_global_stat
    block_timestamp last_block_num;
    uint8_t  revision = 0;
 
+#ifdef TARGET_MAINNET
+   uint8_t  ram_gift_kbytes = 4;
+#endif
+
    EOSLIB_SERIALIZE_DERIVED(gxc_global_state, gxc::blockchain_parameters,
                             (max_ram_size)(total_ram_bytes_reserved)(total_ram_stake)
                             (new_ram_per_block)(last_ram_increase)(last_block_num)(revision)
+#ifdef TARGET_MAINNET
+                            (ram_gift_kbytes)
+#endif
    )
 };
 
@@ -47,7 +54,7 @@ public:
    static constexpr symbol ramcore_symbol = symbol(symbol_code("RAMCORE"), 4);
    static constexpr symbol ram_symbol = symbol(symbol_code("RAM"), 0);
 
-   static constexpr int64_t ram_gift_bytes = 4 * 1024; // 4KiB
+   static int64_t ram_gift_bytes;
 
    static symbol get_core_symbol(name system_account = gxc::system_account) {
       rammarket rm(system_account, system_account.value);
@@ -73,6 +80,9 @@ public:
 
    [[eosio::action]]
    void sellram (name account, int64_t bytes);
+
+   [[eosio::action]]
+   void setramgift(uint8_t kbytes);
 
    [[eosio::action]]
    void refund (name owner);

--- a/contracts/gxc.system/src/delegate_bandwidth.cpp
+++ b/contracts/gxc.system/src/delegate_bandwidth.cpp
@@ -399,4 +399,13 @@ void system_contract::refund( const name owner ) {
    refunds_tbl.erase( req );
 }
 
+void system_contract::setramgift(uint8_t kbytes) {
+   require_auth(_self);
+#ifdef TARGET_MAINNET
+   _gstate.ram_gift_kbytes = kbytes;
+#else
+   check(false, "not possible to adjust ram gift in testnet");
+#endif
+}
+
 }

--- a/contracts/gxc.system/src/gxc.system.cpp
+++ b/contracts/gxc.system/src/gxc.system.cpp
@@ -12,6 +12,10 @@ system_contract::system_contract(name s, name code, datastream<const char*> ds)
 , _rammarket(_self, _self.value)
 , _global(_self, _self.value) {
    _gstate = _global.exists() ? _global.get() : get_default_parameters();
+
+#ifdef TARGET_MAINNET
+   ram_gift_bytes = _gstate.ram_gift_kbytes * 1024;
+#endif
 }
 
 system_contract::~system_contract() {

--- a/contracts/gxc.token/include/gxc.token/config.hpp.in
+++ b/contracts/gxc.token/include/gxc.token/config.hpp.in
@@ -8,10 +8,6 @@
 
 namespace gxc {
    inline uint64_t token_hash(const char* data, uint32_t datalen) {
-#ifdef TARGET_TESTNET
-      return eosio::xxh3_64(data, datalen);
-#else
       return eosio::fasthash64(data, datalen);
-#endif
    }
 }

--- a/contracts/libraries/include/gxclib/token.hpp
+++ b/contracts/libraries/include/gxclib/token.hpp
@@ -34,7 +34,7 @@ asset get_balance(name owner, name issuer, symbol_code sym_code) {
    asset balance;
    auto esc = extended_symbol_code(sym_code, issuer);
    db_get_i64(db_find_i64(token_account.value, issuer.value, "accounts"_n.value,
-                          xxh3_64(reinterpret_cast<const char*>(&esc), sizeof(uint128_t))),
+                          fasthash64(reinterpret_cast<const char*>(&esc), sizeof(uint128_t))),
               reinterpret_cast<void*>(&balance), sizeof(asset));
    return balance;
 }


### PR DESCRIPTION
## Changes

- Use fasthash64 for token primary key 
  `xxHash v3 is still unstable, so use fasthash64 instead.
- Add setramgift to make ram gift adjustable
  Add an action `setramgift`