### PR TITLE
Allow string contract name in HTLC contract

### DIFF
--- a/contracts/gxc.htlc/include/gxc.htlc/gxc.htlc.hpp
+++ b/contracts/gxc.htlc/include/gxc.htlc/gxc.htlc.hpp
@@ -1,5 +1,6 @@
 #include <eosio/eosio.hpp>
 #include <eosio/asset.hpp>
+#include <eoslib/crypto.hpp>
 
 using namespace eosio;
 using std::string;
@@ -11,13 +12,14 @@ public:
    using contract::contract;
 
    struct [[eosio::table]] htlc {
-      name contract_name;
+      string contract_name;
       std::variant<name, checksum160> recipient;
       extended_asset value;
       checksum256 hashlock;
       time_point_sec timelock;
 
-      uint64_t primary_key()const { return contract_name.value; }
+      static uint64_t hash(string s) { return fasthash64(s.data(), s.size()); }
+      uint64_t primary_key()const { return htlc::hash(contract_name); }
 
       EOSLIB_SERIALIZE(htlc, (contract_name)(recipient)(value)(hashlock)(timelock))
    };
@@ -28,13 +30,13 @@ public:
    typedef action_wrapper<"transfer"_n, &htlc_contract::transfer> transfer_action;
 
    [[eosio::action]]
-   void newcontract(name owner, name contract_name, std::variant<name, checksum160> recipient, extended_asset value, checksum256 hashlock, time_point_sec timelock);
+   void newcontract(name owner, string contract_name, std::variant<name, checksum160> recipient, extended_asset value, checksum256 hashlock, time_point_sec timelock);
 
    [[eosio::action]]
-   void withdraw(name owner, name contract_name, checksum256 preimage);
+   void withdraw(name owner, string contract_name, checksum256 preimage);
 
    [[eosio::action]]
-   void cancel(name owner, name contract_name);
+   void cancel(name owner, string contract_name);
 };
 
 }

--- a/contracts/gxc.htlc/src/gxc.htlc.cpp
+++ b/contracts/gxc.htlc/src/gxc.htlc.cpp
@@ -23,7 +23,7 @@ void htlc_contract::newcontract(name owner, string contract_name, std::variant<n
       lck.timelock = timelock;
    });
 
-   transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(owner, _self, value, "FROM " + owner.to_string() + (contract_name.size() ? ", " : "") + contract_name);
+   transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(owner, _self, value, "");
 }
 
 void htlc_contract::withdraw(name owner, string contract_name, checksum256 preimage) {


### PR DESCRIPTION
## Changes 

Fixes #85 

- Accept digest contract name type string in HTLC contract
- Remove debugging statements with a single command