### PR TITLE
Update cancel action to refund action in htlc contract

### DIFF
--- a/contracts/gxc.htlc/include/gxc.htlc/gxc.htlc.hpp
+++ b/contracts/gxc.htlc/include/gxc.htlc/gxc.htlc.hpp
@@ -36,7 +36,7 @@ public:
    void withdraw(name owner, string contract_name, checksum256 preimage);
 
    [[eosio::action]]
-   void cancel(name owner, string contract_name);
+   void refund(name owner, string contract_name);
 };
 
 }

--- a/contracts/gxc.htlc/src/gxc.htlc.cpp
+++ b/contracts/gxc.htlc/src/gxc.htlc.cpp
@@ -21,7 +21,7 @@ void htlc_contract::newcontract(name owner, string contract_name, std::variant<n
       lck.timelock = timelock;
    });
 
-   transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(owner, _self, value, "CREATED FROM " + owner.to_string() + (contract_name.size() ? ", " : "") + contract_name);
+   transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(owner, _self, value, "CREATED BY " + owner.to_string() + (contract_name.size() ? ", " : "") + contract_name);
 }
 
 void htlc_contract::withdraw(name owner, string contract_name, checksum256 preimage) {
@@ -51,7 +51,10 @@ void htlc_contract::refund(name owner, string contract_name) {
 
    check(it.timelock < current_time_point(), "contract not expired");
 
-   transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(_self, owner, it.value, "REFUNDED TO " + std::get<name>(it.recipient).to_string() + (contract_name.size() ? ", " : "") + contract_name);
+   if (std::holds_alternative<name>(it.recipient))
+      transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(_self, owner, it.value, "REFUNDED FROM " + std::get<name>(it.recipient).to_string() + (contract_name.size() ? ", " : "") + contract_name);
+   else
+      transfer_action("gxc.token"_n, {{_self, "active"_n}}).send(_self, owner, it.value, "");
 
    idx.erase(it);
 }


### PR DESCRIPTION
## Changes

- Update cancel action name to refund action
- Add action memo for easy communications
-  Delete overlap string namespace