### PR TITLE
Use global scope instead of owner scope in HTLC

### DIFF
--- a/contracts/gxc.htlc/src/gxc.htlc.cpp
+++ b/contracts/gxc.htlc/src/gxc.htlc.cpp
@@ -10,7 +10,7 @@ namespace gxc {
 void htlc_contract::newcontract(name owner, string contract_name, std::variant<name, checksum160> recipient, extended_asset value, checksum256 hashlock, time_point_sec timelock) {
    require_auth(owner);
 
-   htlcs idx(_self, owner.value);
+   htlcs idx(_self, _self.value);
    check(idx.find(htlc::hash(contract_name)) == idx.end(), "existing contract name");
    check(timelock > current_time_point(), "the expiration time should be in the future");
 
@@ -26,7 +26,7 @@ void htlc_contract::newcontract(name owner, string contract_name, std::variant<n
 }
 
 void htlc_contract::withdraw(name owner, string contract_name, checksum256 preimage) {
-   htlcs idx(_self, owner.value);
+   htlcs idx(_self, _self.value);
    const auto& it = idx.get(htlc::hash(contract_name));
 
    // `preimage` works as a key here.
@@ -47,7 +47,7 @@ void htlc_contract::withdraw(name owner, string contract_name, checksum256 preim
 void htlc_contract::refund(name owner, string contract_name) {
    require_auth(owner);
 
-   htlcs idx(_self, owner.value);
+   htlcs idx(_self, _self.value);
    const auto& it = idx.get(htlc::hash(contract_name));
 
    check(it.timelock < current_time_point(), "contract not expired");


### PR DESCRIPTION
## Changes
Fixes #90 

- before `owner` scope, after `_self` scope