### PR TITLE
Fix Duplicate delete err in gacha contract

### DIFF
--- a/contracts/gacha/gacha.cpp
+++ b/contracts/gacha/gacha.cpp
@@ -154,8 +154,6 @@ void gacha::resolve() {
       if (git.deadline > current_time_point()) break;
 
       resolve_one(git.id);
-
-      deadline.erase(it);
    }
 
    refresh_schedule();


### PR DESCRIPTION
The `draw` action itself automatically deletes row in gacha table.
Therefore, the `resolve` action raises an error that there is no row for rows that have already been deleted.